### PR TITLE
Fixes crashing tests issue.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -265,10 +265,10 @@ project(":core") {
     compileJava.dependsOn extractOpenCvNatives
 
     tasks.withType(JavaExec) {
-        systemProperty "java.library.path", "$nativeLibDir/jni/"
+        systemProperty "java.library.path", "$nativeLibDir/opencv-jni/"
     }
     tasks.withType(Test) {
-        systemProperty "java.library.path", "$nativeLibDir/jni/"
+        systemProperty "java.library.path", "$nativeLibDir/opencv-jni/"
     }
 
     shadowJar {
@@ -327,6 +327,7 @@ project(":ui") {
         ideProvider project(path: ':core', configuration: 'compile')
         compile group: 'org.controlsfx', name: 'controlsfx', version: '8.40.10'
         compile group: 'com.hierynomus', name: 'sshj', version: '0.16.0'
+        testCompile project(path: ':core', configuration: 'shadow')
         testCompile files(project(':core').sourceSets.test.output.classesDir)
         testCompile files(project(':core').sourceSets.test.output.resourcesDir)
         testCompile group: 'org.testfx', name: 'testfx-core', version: '4.0.+'

--- a/core/src/main/java/edu/wpi/grip/core/GripCoreModule.java
+++ b/core/src/main/java/edu/wpi/grip/core/GripCoreModule.java
@@ -1,6 +1,7 @@
 package edu.wpi.grip.core;
 
 import edu.wpi.grip.core.events.UnexpectedThrowableEvent;
+import edu.wpi.grip.core.natives.NativesLoader;
 import edu.wpi.grip.core.serialization.Project;
 import edu.wpi.grip.core.settings.SettingsProvider;
 import edu.wpi.grip.core.sockets.InputSocket;
@@ -94,6 +95,7 @@ public class GripCoreModule extends AbstractModule {
     } catch (IOException exception) { //Something happened setting up file IO
       throw new IllegalStateException("Failed to configure the Logger", exception);
     }
+    NativesLoader.load();
   }
 
   /*

--- a/core/src/main/java/edu/wpi/grip/core/natives/NativesLoader.java
+++ b/core/src/main/java/edu/wpi/grip/core/natives/NativesLoader.java
@@ -66,7 +66,7 @@ public final class NativesLoader {
       String osName = System.getProperty("os.name");
       final boolean onWindows = osName.startsWith("Windows");
       final boolean onMac = osName.startsWith("Mac");
-      String resName = "/jni/";
+      String resName = "/opencv-jni/";
       if (onWindows) {
         resName += "opencv_java" + version + ".dll";
       } else if (onMac) {

--- a/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewPointOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewPointOperation.java
@@ -5,6 +5,7 @@ import edu.wpi.grip.core.OperationDescription;
 import edu.wpi.grip.core.sockets.InputSocket;
 import edu.wpi.grip.core.sockets.OutputSocket;
 import edu.wpi.grip.core.sockets.SocketHint;
+import edu.wpi.grip.core.sockets.SocketHint.View;
 import edu.wpi.grip.core.sockets.SocketHints;
 import edu.wpi.grip.core.util.Icon;
 
@@ -22,13 +23,18 @@ public class NewPointOperation implements CVOperation {
           .summary("Create a point by (x,y) value.")
           .icon(Icon.iconStream("point"))
           .build();
-
-  private final SocketHint<Number> xHint = SocketHints.Inputs.createNumberSpinnerSocketHint("x", -1,
+  private final int initX = -1;
+  private final int initY = -1;
+  private final SocketHint<Number> xHint = SocketHints.Inputs
+      .createNumberSpinnerSocketHint("x", initX,
       Integer.MIN_VALUE, Integer.MAX_VALUE);
-  private final SocketHint<Number> yHint = SocketHints.Inputs.createNumberSpinnerSocketHint("y", -1,
+  private final SocketHint<Number> yHint = SocketHints.Inputs
+      .createNumberSpinnerSocketHint("y", initY,
       Integer.MIN_VALUE, Integer.MAX_VALUE);
-  private final SocketHint<Point> outputHint = SocketHints.Outputs.createPointSocketHint("point");
-
+  private final SocketHint<Point> outputHint = new SocketHint.Builder<Point>(Point.class)
+      .identifier("point")
+      .initialValueSupplier(() -> new Point(initX, initY))
+      .view(View.NONE).build();
 
   private final InputSocket<Number> xSocket;
   private final InputSocket<Number> ySocket;
@@ -42,8 +48,6 @@ public class NewPointOperation implements CVOperation {
     this.ySocket = inputSocketFactory.create(yHint);
 
     this.outputSocket = outputSocketFactory.create(outputHint);
-    
-    this.perform();//So initial value is correct.
   }
 
   @Override

--- a/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewPointOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewPointOperation.java
@@ -42,6 +42,8 @@ public class NewPointOperation implements CVOperation {
     this.ySocket = inputSocketFactory.create(yHint);
 
     this.outputSocket = outputSocketFactory.create(outputHint);
+    
+    this.perform();//So initial value is correct.
   }
 
   @Override

--- a/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewSizeOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewSizeOperation.java
@@ -5,6 +5,7 @@ import edu.wpi.grip.core.OperationDescription;
 import edu.wpi.grip.core.sockets.InputSocket;
 import edu.wpi.grip.core.sockets.OutputSocket;
 import edu.wpi.grip.core.sockets.SocketHint;
+import edu.wpi.grip.core.sockets.SocketHint.View;
 import edu.wpi.grip.core.sockets.SocketHints;
 import edu.wpi.grip.core.util.Icon;
 
@@ -22,11 +23,16 @@ public class NewSizeOperation implements CVOperation {
           .icon(Icon.iconStream("size"))
           .build();
 
+  private final int initWidth = -1;
+  private final int initHeight = -1;
   private final SocketHint<Number> widthHint = SocketHints.Inputs
-      .createNumberSpinnerSocketHint("width", -1, -1, Integer.MAX_VALUE);
+      .createNumberSpinnerSocketHint("width", initWidth, -1, Integer.MAX_VALUE);
   private final SocketHint<Number> heightHint = SocketHints.Inputs
-      .createNumberSpinnerSocketHint("height", -1, -1, Integer.MAX_VALUE);
-  private final SocketHint<Size> outputHint = SocketHints.Outputs.createSizeSocketHint("size");
+      .createNumberSpinnerSocketHint("height", initHeight, -1, Integer.MAX_VALUE);
+  private final SocketHint<Size> outputHint = new SocketHint.Builder<Size>(Size.class)
+      .identifier("size")
+      .initialValueSupplier(() -> new Size(initWidth, initHeight))
+      .view(View.NONE).build();
 
 
   private final InputSocket<Number> widthSocket;
@@ -41,8 +47,6 @@ public class NewSizeOperation implements CVOperation {
     this.heightSocket = inputSocketFactory.create(heightHint);
 
     this.outputSocket = outputSocketFactory.create(outputHint);
-    
-    this.perform();//So initial value is correct.
   }
 
   @Override

--- a/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewSizeOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewSizeOperation.java
@@ -41,6 +41,8 @@ public class NewSizeOperation implements CVOperation {
     this.heightSocket = inputSocketFactory.create(heightHint);
 
     this.outputSocket = outputSocketFactory.create(outputHint);
+    
+    this.perform();//So initial value is correct.
   }
 
   @Override

--- a/ui/src/test/java/edu/wpi/grip/ui/preview/PointSizeSocketPreviewViewTest.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/preview/PointSizeSocketPreviewViewTest.java
@@ -59,8 +59,8 @@ public class PointSizeSocketPreviewViewTest {
     public void testForExpectedValues() {
       WaitForAsyncUtils.waitForFxEvents();
       verifyThat(identifier, NodeMatchers.isVisible());
-      verifyThat(Integer.toString(value1), NodeMatchers.isVisible());
-      verifyThat(Integer.toString(value2), NodeMatchers.isVisible());
+      verifyThat(Double.toString(value1), NodeMatchers.isVisible());
+      verifyThat(Double.toString(value2), NodeMatchers.isVisible());
     }
 
 
@@ -101,8 +101,8 @@ public class PointSizeSocketPreviewViewTest {
     public void testForExpectedValues() {
       WaitForAsyncUtils.waitForFxEvents();
       verifyThat(identifier, NodeMatchers.isVisible());
-      verifyThat(Integer.toString(value1), NodeMatchers.isVisible());
-      verifyThat(Integer.toString(value2), NodeMatchers.isVisible());
+      verifyThat(Double.toString(value1), NodeMatchers.isVisible());
+      verifyThat(Double.toString(value2), NodeMatchers.isVisible());
     }
 
     @After


### PR DESCRIPTION
UI tests were not calling NativesLoader properly before starting, and thus the first time any Opencv class was referenced it would fail. 

Now GripCoreModule ensures that NativesLoader is always called before setup of the CoreModule which contains most of the Opencv references.

All tests should work now. 
